### PR TITLE
Capturando error de parseo cuando el body es un JSON

### DIFF
--- a/libs/cirrus.js
+++ b/libs/cirrus.js
@@ -168,7 +168,7 @@ function http_parser(http_request, type) {
 
 // xxxxxxxxxxxxxxxxxxxxxxxxx Request Object xxxxxxxxxxxxxx
     function Request(http_request) {
-      try
+      try{
           var req = http_parser(http_request);
           wApp.router.params = req.decodeParams;
   
@@ -179,7 +179,7 @@ function http_parser(http_request, type) {
           // Set Cookie
           if(req.headers.Cookie !== undefined) { wApp.session.getFromHeader(req.headers.Cookie); }
           return(req);
-        catch(e){return(e);} // Capturamos el error de parseo del JSON
+        }catch(e){return(e);} // Capturamos el error de parseo del JSON
     }
 
     function getType(str){


### PR DESCRIPTION
Se añade controles para enviar un una cabecera 500 cuando se produce un SyntaxError durante el parseo del request, en este caso cuando se recibe un JSON en el body y no es correcto.
Actualmente el vServer devuelve el mensaje de "Unable to parse JSON string" pero no se devuelve nada al cliente.
